### PR TITLE
Fix validations and preserve old form data

### DIFF
--- a/app/Http/Controllers/Admin/ConsoleController.php
+++ b/app/Http/Controllers/Admin/ConsoleController.php
@@ -60,19 +60,19 @@ class ConsoleController extends Controller
      */
     public function store(Request $request)
     {
-        $console = Console::firstOrCreate([
-            'name' => $request->input('name'),
+        $validated = $request->validate([
+            'name' => 'required|string|max:255|unique:consoles,name',
+        ], [
+            'name.required' => 'Il nome è obbligatorio!',
+            'name.unique' => 'Questa console esiste già!',
+            'name.max' => 'Il nome non può superare i 255 caratteri.',
         ]);
 
-        if ($console->wasRecentlyCreated) {
-            return redirect()->route('admin.consoles.index')
-                ->with('message', 'Console aggiunta con successo.')
-                ->with('message_type', 'success');;
-        } else {
-            return redirect()->route('admin.consoles.index')
-                ->with('message', 'Console già esistente.')
-                ->with('message_type', 'error');;
-        }
+        $console = Console::create($validated);
+
+        return redirect()->route('admin.consoles.index')
+            ->with('message', 'Console aggiunta con successo.')
+            ->with('message_type', 'success');
     }
 
     /**
@@ -117,7 +117,7 @@ class ConsoleController extends Controller
 
         return redirect()->route('admin.consoles.index')
             ->with('message', 'Console aggiornata con successo!')
-            ->with('message_type', 'success');;
+            ->with('message_type', 'success');
     }
 
     /**
@@ -127,6 +127,8 @@ class ConsoleController extends Controller
     {
         $console->delete();
 
-        return redirect()->route('admin.consoles.index');
+        return redirect()->route('admin.consoles.index')
+            ->with('message', 'Console eliminata con successo!')
+            ->with('message_type', 'success');
     }
 }

--- a/app/Http/Controllers/Admin/DeveloperController.php
+++ b/app/Http/Controllers/Admin/DeveloperController.php
@@ -60,19 +60,19 @@ class DeveloperController extends Controller
      */
     public function store(Request $request)
     {
-        $developer = Developer::firstOrCreate([
-            'name' => $request->input('name'),
+        $validated = $request->validate([
+            'name' => 'required|string|max:255|unique:developers,name',
+        ], [
+            'name.required' => 'Il nome è obbligatorio!',
+            'name.unique' => 'Questo developer esiste già!',
+            'name.max' => 'Il nome non può superare i 255 caratteri.',
         ]);
 
-        if ($developer->wasRecentlyCreated) {
-            return redirect()->route('admin.developers.index')
-                ->with('message', 'Developer aggiunto con successo.')
-                ->with('message_type', 'success');;
-        } else {
-            return redirect()->route('admin.developers.index')
-                ->with('message', 'Developer già esistente.')
-                ->with('message_type', 'error');;
-        }
+        Developer::create($validated);
+
+        return redirect()->route('admin.developers.index')
+            ->with('message', 'Developer aggiunto con successo.')
+            ->with('message_type', 'success');
     }
 
     /**
@@ -117,7 +117,7 @@ class DeveloperController extends Controller
 
         return redirect()->route('admin.developers.index')
             ->with('message', 'Developer aggiornato con successo!')
-            ->with('message_type', 'success');;
+            ->with('message_type', 'success');
     }
 
     /**
@@ -127,6 +127,8 @@ class DeveloperController extends Controller
     {
         $developer->delete();
 
-        return redirect()->route('admin.developers.index');
+        return redirect()->route('admin.developers.index')
+            ->with('message', 'Developer eliminato con successo!')
+            ->with('message_type', 'success');
     }
 }

--- a/app/Http/Controllers/Admin/GenreController.php
+++ b/app/Http/Controllers/Admin/GenreController.php
@@ -60,19 +60,19 @@ class GenreController extends Controller
      */
     public function store(Request $request)
     {
-        $genre = Genre::firstOrCreate([
-            'name' => $request->input('name'),
+        $validated = $request->validate([
+            'name' => 'required|string|max:255|unique:genres,name',
+        ], [
+            'name.required' => 'Il nome è obbligatorio!',
+            'name.unique' => 'Questo genere esiste già!',
+            'name.max' => 'Il nome non può superare i 255 caratteri.',
         ]);
 
-        if ($genre->wasRecentlyCreated) {
-            return redirect()->route('admin.genres.index')
-                ->with('message', 'Genere aggiunto con successo.')
-                ->with('message_type', 'success');;
-        } else {
-            return redirect()->route('admin.genres.index')
-                ->with('message', 'Genere già esistente.')
-                ->with('message_type', 'error');;
-        }
+        Genre::create($validated);
+
+        return redirect()->route('admin.genres.index')
+            ->with('message', 'Genere aggiunto con successo!')
+            ->with('message_type', 'success');
     }
 
     /**
@@ -117,7 +117,7 @@ class GenreController extends Controller
 
         return redirect()->route('admin.genres.index')
             ->with('message', 'Genere aggiornato con successo!')
-            ->with('message_type', 'success');;
+            ->with('message_type', 'success');
     }
 
     /**
@@ -127,6 +127,8 @@ class GenreController extends Controller
     {
         $genre->delete();
 
-        return redirect()->route('admin.genres.index');
+        return redirect()->route('admin.genres.index')
+            ->with('message', 'Genere eliminato con successo!')
+            ->with('message_type', 'success');
     }
 }

--- a/resources/views/admin/consoles/index.blade.php
+++ b/resources/views/admin/consoles/index.blade.php
@@ -96,6 +96,17 @@
         </div>
 
         <div class="col-4">
+            @if ($errors->any())
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <ul class="mb-0">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+            @endif
+
             <form action="{{ route('admin.consoles.store') }}" method="POST">
                 @csrf
 
@@ -104,7 +115,7 @@
                 <div class="row d-flex justify-content-center">
                     <div class="col-10">
                         <label for="name" class="form-label">Nome nuova console</label>
-                        <input type="text" class="form-control" id="name" name="name" required>
+                        <input type="text" class="form-control" id="name" name="name" value="{{ old('name') }}" required>
                     </div>
 
                     <div class="col-5">

--- a/resources/views/admin/developers/index.blade.php
+++ b/resources/views/admin/developers/index.blade.php
@@ -97,6 +97,17 @@
         </div>
 
         <div class="col-4">
+            @if ($errors->any())
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <ul class="mb-0">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+            @endif
+
             <form action="{{ route('admin.developers.store') }}" method="POST">
                 @csrf
 
@@ -105,11 +116,11 @@
                 <div class="row d-flex justify-content-center">
                     <div class="col-10">
                         <label for="name" class="form-label">Nome nuova casa produttrice</label>
-                        <input type="text" class="form-control" id="name" name="name" required>
+                        <input type="text" class="form-control" id="name" name="name" value="{{ old('name') }}" required>
                     </div>
 
                     <div class="col-5">
-                        <button type="submit" class="btn btn-primary mt-3">Aggiungi console</button>
+                        <button type="submit" class="btn btn-primary mt-3">Aggiungi developer</button>
                     </div>
                 </div>
             </form>

--- a/resources/views/admin/games/create.blade.php
+++ b/resources/views/admin/games/create.blade.php
@@ -4,6 +4,17 @@
 
 @section('content')
 
+    @if ($errors->any())
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+
     <h2 class="py-3">Crea un nuovo gioco</h2>
 
     <form action="{{ route('admin.games.store') }}" method="POST" enctype="multipart/form-data">
@@ -11,12 +22,12 @@
         <div class="row">
             <div class="col-10 mb-3">
                 <label for="title" class="form-label">Titolo</label>
-                <input type="text" class="form-control" id="title" name="title" required>
+                <input type="text" class="form-control" id="title" name="title" value="{{ old('title') }}" required>
             </div>
 
             <div class="col-2 mb-3">
                 <label for="release_date" class="form-label">Data di rilascio</label>
-                <input type="date" id="release_date" name="release_date" class="form-control" required>
+                <input type="date" id="release_date" name="release_date" class="form-control" value="{{ old('release_date') }}" required>
             </div>
 
             <div class="col-12 mb-3">
@@ -38,7 +49,8 @@
                         @foreach ($consoles as $console)
                             <div class="form-check">
                                 <input class="form-check-input" type="checkbox" name="consoles[]"
-                                    value="{{ $console->id }}" id="console-{{ $console->id }}">
+                                    value="{{ $console->id }}" id="console-{{ $console->id }}"
+                                    {{ in_array($console->id, old('consoles', [])) ? 'checked' : '' }}>
                                 <label class="form-check-label" for="console-{{ $console->id }}">
                                     {{ $console->name }}
                                 </label>
@@ -56,7 +68,7 @@
                         @foreach ($genres as $genre)
                             <div class="form-check">
                                 <input class="form-check-input" type="checkbox" name="genres[]" value="{{ $genre->id }}"
-                                    id="genre-{{ $genre->id }}">
+                                    id="genre-{{ $genre->id }}" {{ in_array($genre->id, old('genres', [])) ? 'checked' : '' }}>
                                 <label class="form-check-label" for="genre-{{ $genre->id }}">
                                     {{ $genre->name }}
                                 </label>
@@ -68,8 +80,8 @@
             </div>
 
             <div class="col-12 mb-3">
-                <label for="short_descriprion" class="form-label">Descrizione</label>
-                <textarea id="short_description" name="short_description" rows="4" class="form-control" required></textarea>
+                <label for="short_description" class="form-label">Descrizione</label>
+                <textarea id="short_description" name="short_description" rows="4" class="form-control" required>{{ old('short_description') }}</textarea>
             </div>
 
             <div class="col-12 mb-3">

--- a/resources/views/admin/genres/index.blade.php
+++ b/resources/views/admin/genres/index.blade.php
@@ -96,6 +96,17 @@
         </div>
 
         <div class="col-4">
+            @if ($errors->any())
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <ul class="mb-0">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+            @endif
+
             <form action="{{ route('admin.genres.store') }}" method="POST">
                 @csrf
 
@@ -104,7 +115,7 @@
                 <div class="row d-flex justify-content-center">
                     <div class="col-10">
                         <label for="name" class="form-label">Nome nuova genere</label>
-                        <input type="text" class="form-control" id="name" name="name" required>
+                        <input type="text" class="form-control" id="name" name="name" value="{{ old('name') }}" required>
                     </div>
 
                     <div class="col-5">


### PR DESCRIPTION
## Summary
- validate data in admin controllers when creating records
- return success messages consistently via `message` and `message_type`
- fix attachment bug in `GameController` and clean syntax
- show validation errors in admin forms and preserve input with `old()`
- minor label fixes and tidy up

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68476c6c05dc8325819a52e20b582f3b